### PR TITLE
Minor updates to get full_fov experiment working.

### DIFF
--- a/experiment_prototype/experiment_prototype.py
+++ b/experiment_prototype/experiment_prototype.py
@@ -305,7 +305,7 @@ therefore ignored.
 
 possible_averaging_methods = frozenset(['mean', 'median'])
 possible_scheduling_modes = frozenset(['common', 'special', 'discretionary'])
-default_rx_bandwidth = 5.0e6
+default_rx_bandwidth = 500e3
 default_output_rx_rate = 10.0e3/3
 transition_bandwidth = 37500.0
 

--- a/experiments/full_fov.py
+++ b/experiments/full_fov.py
@@ -50,13 +50,13 @@ class FullFOV(ExperimentPrototype):
             "first_range": scf.STD_FIRST_RANGE,
             "intt": scf.INTT_7P_24,  # duration of an integration, in ms
             "beam_angle": scf.STD_24_BEAM_ANGLE,
-            "rx_beam_order": [[i for i in range(num_antennas)]],
+            "rx_beam_order": [scf.STD_24_FORWARD_BEAM_ORDER],
             "tx_beam_order": [0],   # only one pattern
             "tx_antenna_pattern": scf.easy_widebeam,
             "freq": freq,  # kHz
             "acf": True,
             "xcf": True,  # cross-correlation processing
             "acfint": True,  # interferometer acfs
-            "align_sequences": True     # align start of sequence to tenths of a second
+            #"align_sequences": True     # align start of sequence to tenths of a second
         })
 


### PR DESCRIPTION
* Use 24 beams simultaneously on RX for `full_fov` experiment
* Allow 12.8016m spacing in `superdarn_common_fields.easy_widebeam()`
* Update default RX bandwidth to 0.5 MHz for ALL EXPERIMENTS
* Don't align sequences in `full_fov` experiment